### PR TITLE
fix: remove compilator warnings from tests

### DIFF
--- a/tests/test_ClockSimulator.cpp
+++ b/tests/test_ClockSimulator.cpp
@@ -38,7 +38,8 @@ TEST(ClockSimulatorTest, timerfd)
     std::atomic<bool> sleep_finished = false;
     assert_sleeps_for(clock, LONG_DURATION, [&sleep_finished, fd] {
         uint64_t buf;
-        read(fd, &buf, sizeof(buf));
+        assert(read(fd, &buf, sizeof(buf)) == 0);
+        (void)buf;
         sleep_finished = true;
     });
 }

--- a/tests/test_fakeclock.cpp
+++ b/tests/test_fakeclock.cpp
@@ -19,13 +19,15 @@ TEST(FakeClockTest, select)
         struct timeval tv = to_timeval(LONG_DURATION);
         fd_set readfds;
         FD_ZERO(&readfds);
-        int fds[2];
-        pipe(fds);
+        int fds[2] = {0, 0};
+        assert(pipe(fds) == 0);
         FD_SET(fds[0], &readfds);
         // select_result = select(1, &readfds, nullptr, nullptr, &tv);
         select_result = select(fds[0] + 1, &readfds, nullptr, nullptr, &tv);
-        close(fds[0]);
-        close(fds[1]);
+
+        assert(close(fds[0]) == 0);
+        assert(close(fds[1]) == 0);
+
         operation_finished = true;
     });
     ASSERT_EQ(select_result, 0);

--- a/tests/test_gettime.cpp
+++ b/tests/test_gettime.cpp
@@ -14,10 +14,10 @@ TEST(FakeClockGetTest, gettimeofday)
 {
     MasterOfTime clock; // Take control of time
     struct timeval tv;
-    gettimeofday(&tv, nullptr);
+    assert(gettimeofday(&tv, nullptr) == 0);
     auto start = std::chrono::seconds(tv.tv_sec) + std::chrono::microseconds(tv.tv_usec);
     clock.advance(LONG_DURATION);
-    gettimeofday(&tv, nullptr);
+    assert(gettimeofday(&tv, nullptr) == 0);
     auto end = std::chrono::seconds(tv.tv_sec) + std::chrono::microseconds(tv.tv_usec);
     auto duration = end - start;
     ASSERT_EQ(duration, LONG_DURATION);
@@ -27,10 +27,10 @@ TEST(FakeClockGetTest, clock_gettime)
 {
     MasterOfTime clock; // Take control of time
     struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
+    assert(clock_gettime(CLOCK_REALTIME, &ts) == 0);
     auto start = std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec);
     clock.advance(LONG_DURATION);
-    clock_gettime(CLOCK_REALTIME, &ts);
+    assert(clock_gettime(CLOCK_REALTIME, &ts) == 0);
     auto end = std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec);
     auto duration = end - start;
     ASSERT_EQ(duration, LONG_DURATION);
@@ -40,10 +40,10 @@ TEST(FakeClockGetTest, clock_gettime_monotonic)
 {
     MasterOfTime clock; // Take control of time
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    assert(clock_gettime(CLOCK_MONOTONIC, &ts) == 0);
     auto start = std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec);
     clock.advance(LONG_DURATION);
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    assert(clock_gettime(CLOCK_MONOTONIC, &ts) == 0);
     auto end = std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec);
     auto duration = end - start;
     ASSERT_EQ(duration, LONG_DURATION);
@@ -53,10 +53,10 @@ TEST(FakeClockGetTest, clock_gettime_monotonic_raw)
 {
     MasterOfTime clock; // Take control of time
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    assert(clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0);
     auto start = std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec);
     clock.advance(LONG_DURATION);
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    assert(clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0);
     auto end = std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec);
     auto duration = end - start;
     ASSERT_EQ(duration, LONG_DURATION);

--- a/tests/test_sleep.cpp
+++ b/tests/test_sleep.cpp
@@ -15,14 +15,15 @@ TEST(FakeClockSleepTest, usleep)
 {
     MasterOfTime clock; // Take control of time
     static constexpr int SLEEP_DURATION_US = 1;
-    assert_sleeps_for(clock, std::chrono::microseconds(SLEEP_DURATION_US), [] { usleep(SLEEP_DURATION_US); });
+    assert_sleeps_for(clock, std::chrono::microseconds(SLEEP_DURATION_US),
+                      [] { assert(usleep(SLEEP_DURATION_US) == 0); });
 }
 
 TEST(FakeClockSleepTest, sleep)
 {
     MasterOfTime clock; // Take control of time
     static constexpr int SLEEP_DURATION_S = 1;
-    assert_sleeps_for(clock, std::chrono::seconds(SLEEP_DURATION_S), [] { sleep(SLEEP_DURATION_S); });
+    assert_sleeps_for(clock, std::chrono::seconds(SLEEP_DURATION_S), [] { assert(sleep(SLEEP_DURATION_S) == 0); });
 }
 
 TEST(FakeClockSleepTest, nanosleep)
@@ -32,7 +33,8 @@ TEST(FakeClockSleepTest, nanosleep)
     struct timespec ts;
     ts.tv_sec = 0;
     ts.tv_nsec = SLEEP_DURATION_NS;
-    assert_sleeps_for(clock, std::chrono::nanoseconds(SLEEP_DURATION_NS), [ts] { nanosleep(&ts, nullptr); });
+    assert_sleeps_for(clock, std::chrono::nanoseconds(SLEEP_DURATION_NS),
+                      [ts] { assert(nanosleep(&ts, nullptr) == 0); });
 }
 
 TEST(FakeClockSleepTest, this_thread_sleep_for)


### PR DESCRIPTION
Merge it at your own responisibillity!
Once i compiled this code without any warnings, the tests fail in my environment.

On arm (or qemu) this test fails right away:
```
Running main() from /usr/src/debug/googletest/1.14.0-r0/googletest/src/gtest_main.cc
[==========] Running 29 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 1 test from FakeClockTest
[ RUN      ] FakeClockTest.select
/home/akuca/rep/evpu/fakeclock/tests/test_helpers.h:37: Failure
Value of: wait_for([&] -> bool { return sleep_finished; })
  Actual: true
Expected: false
```

On x86 it fails somewhere else:
```
[==========] Running 29 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 1 test from FakeClockTest
[ RUN      ] FakeClockTest.select
[       OK ] FakeClockTest.select (2 ms)
[----------] 1 test from FakeClockTest (2 ms total)

[----------] 3 tests from FakeClockBoostTest
[ RUN      ] FakeClockBoostTest.boost_posix_time_local_time
[       OK ] FakeClockBoostTest.boost_posix_time_local_time (0 ms)
[ RUN      ] FakeClockBoostTest.asio_steady_timer_wait
[       OK ] FakeClockBoostTest.asio_steady_timer_wait (0 ms)
[ RUN      ] FakeClockBoostTest.asio_steady_timer_wait_in_background
[       OK ] FakeClockBoostTest.asio_steady_timer_wait_in_background (2 ms)
[----------] 3 tests from FakeClockBoostTest (2 ms total)

[----------] 3 tests from ClockSimulatorTest
[ RUN      ] ClockSimulatorTest.now
[       OK ] ClockSimulatorTest.now (0 ms)
[ RUN      ] ClockSimulatorTest.waitUntil
[       OK ] ClockSimulatorTest.waitUntil (2 ms)
[ RUN      ] ClockSimulatorTest.timerfd
[       OK ] ClockSimulatorTest.timerfd (2 ms)
[----------] 3 tests from ClockSimulatorTest (4 ms total)

[----------] 11 tests from TimerFdTest
[ RUN      ] TimerFdTest.check_eventfd_closing_detector
[       OK ] TimerFdTest.check_eventfd_closing_detector (0 ms)
[ RUN      ] TimerFdTest.timerfd_create_and_settime
[       OK ] TimerFdTest.timerfd_create_and_settime (2 ms)
[ RUN      ] TimerFdTest.timerfd_create_and_settime_abstime
/home/akuca/rep/evpu/fakeclock/tests/test_helpers.h:39: Failure
Value of: wait_for([&] -> bool { return sleep_finished; })
  Actual: false
Expected: true

terminate called without an active exception

Aborted (core dumped)
```

