### PR TITLE
Address PR feedback: socket timeouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(test_fakeclock
     tests/test_gettime.cpp
     tests/test_clock_nanosleep.cpp
     tests/test_posix_timer.cpp
+    tests/test_socket_timeout.cpp
 )
 # Link the library and Google Test to the test executable
 target_link_libraries(test_fakeclock fakeclock GTest::gtest GTest::gtest_main pthread)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ FakeClock is a simple C++ library for simulating and manipulating time in your u
 - **Non-Intrusive Integration:** Replaces standard C++ functions like `std::this_thread::sleep_for` and `std::chrono::system_clock::now` without needing invasive code changes.
 - **Deterministic Testing:** Ensures that tests produce predictable results by decoupling them from the real system clock.
 - **Lightweight and Focused:** Minimalistic design with no external dependencies.
+- **Socket Timeouts:** `connect`, `recv`, and `send` respect `SO_RCVTIMEO` and `SO_SNDTIMEO` when the clock is controlled.
 
 ---
 

--- a/include/fakeclock/common.h
+++ b/include/fakeclock/common.h
@@ -5,6 +5,8 @@
 namespace fakeclock
 {
 
+constexpr auto SOCKET_CHECK_INTERVAL = std::chrono::milliseconds(1);
+
 inline timeval to_timeval(std::chrono::nanoseconds us)
 {
     timeval tv;

--- a/include/fakeclock/common.h
+++ b/include/fakeclock/common.h
@@ -26,4 +26,9 @@ inline std::chrono::nanoseconds to_duration(const timespec &ts)
     return std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec);
 }
 
+inline std::chrono::nanoseconds to_duration(const timeval &tv)
+{
+    return std::chrono::seconds(tv.tv_sec) + std::chrono::microseconds(tv.tv_usec);
+}
+
 } // namespace fakeclock

--- a/src/overrides.cpp
+++ b/src/overrides.cpp
@@ -371,7 +371,6 @@ extern "C"
 
 extern "C" {
 
-    static constexpr auto CHECK_INTERVAL = std::chrono::milliseconds(1);
 
     int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
     {
@@ -447,7 +446,7 @@ extern "C" {
         while (simulator.now() - start < timeout)
         {
             auto remaining = timeout - (simulator.now() - start);
-            auto step = std::min(remaining, std::chrono::duration_cast<std::chrono::nanoseconds>(CHECK_INTERVAL));
+            auto step = std::min(remaining, std::chrono::duration_cast<std::chrono::nanoseconds>(fakeclock::SOCKET_CHECK_INTERVAL));
             simulator.waitUntil(simulator.now() + step);
             ret = real_recv(sockfd, buf, len, flags | MSG_DONTWAIT);
             if (ret != -1 || errno != EAGAIN)
@@ -478,7 +477,7 @@ extern "C" {
         while (simulator.now() - start < timeout)
         {
             auto remaining = timeout - (simulator.now() - start);
-            auto step = std::min(remaining, std::chrono::duration_cast<std::chrono::nanoseconds>(CHECK_INTERVAL));
+            auto step = std::min(remaining, std::chrono::duration_cast<std::chrono::nanoseconds>(fakeclock::SOCKET_CHECK_INTERVAL));
             simulator.waitUntil(simulator.now() + step);
             ret = real_send(sockfd, buf, len, flags | MSG_DONTWAIT);
             if (ret != -1 || errno != EAGAIN)

--- a/tests/test_socket_timeout.cpp
+++ b/tests/test_socket_timeout.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <chrono>
 #include <fakeclock/fakeclock.h>
+#include <fakeclock/common.h>
 #include <gtest/gtest.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -10,7 +11,7 @@
 using namespace std::chrono_literals;
 
 static constexpr auto SOCKET_TIMEOUT = 1s;
-static constexpr auto SOCKET_CHECK_INTERVAL = 1ms;
+
 
 TEST(SocketTimeoutTest, RecvTimeout)
 {
@@ -70,7 +71,7 @@ TEST(SocketTimeoutTest, RecvDataBeforeTimeout)
 
     clock.advance(SOCKET_TIMEOUT / 2);
     ASSERT_EQ(send(sv[1], "abc", 3, 0), 3);
-    clock.advance(SOCKET_CHECK_INTERVAL);
+    clock.advance(fakeclock::SOCKET_CHECK_INTERVAL);
     receiver.join();
     EXPECT_EQ(result, 3);
     EXPECT_EQ(std::string(buf, result), "abc");

--- a/tests/test_socket_timeout.cpp
+++ b/tests/test_socket_timeout.cpp
@@ -1,0 +1,81 @@
+#include "test_helpers.h"
+#include <atomic>
+#include <chrono>
+#include <fakeclock/fakeclock.h>
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+using namespace std::chrono_literals;
+
+static constexpr auto SOCKET_TIMEOUT = 1s;
+static constexpr auto SOCKET_CHECK_INTERVAL = 1ms;
+
+TEST(SocketTimeoutTest, RecvTimeout)
+{
+    fakeclock::MasterOfTime clock; // Take control of time
+    int sv[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+
+    struct timeval tv = fakeclock::to_timeval(SOCKET_TIMEOUT);
+    ASSERT_EQ(setsockopt(sv[0], SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)), 0);
+
+    char buf[4];
+    std::atomic<ssize_t> result = 0;
+    std::atomic<int> err = 0;
+    assert_sleeps_for(clock, SOCKET_TIMEOUT, [&] {
+        result = recv(sv[0], buf, sizeof(buf), 0);
+        err = errno;
+    });
+    EXPECT_EQ(result, -1);
+    EXPECT_EQ(err, EAGAIN);
+
+    close(sv[0]);
+    close(sv[1]);
+}
+
+TEST(SocketTimeoutTest, RecvWithoutTimeout)
+{
+    fakeclock::MasterOfTime clock;
+    int sv[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+
+    char buf[4];
+    ssize_t result = recv(sv[0], buf, sizeof(buf), 0);
+    EXPECT_EQ(result, -1);
+    EXPECT_EQ(errno, EAGAIN);
+
+    close(sv[0]);
+    close(sv[1]);
+}
+
+TEST(SocketTimeoutTest, RecvDataBeforeTimeout)
+{
+    fakeclock::MasterOfTime clock;
+    int sv[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+
+    struct timeval tv = fakeclock::to_timeval(SOCKET_TIMEOUT);
+    ASSERT_EQ(setsockopt(sv[0], SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)), 0);
+
+    char buf[4] = {};
+    std::atomic<ssize_t> result = 0;
+    std::atomic<bool> ready = false;
+    std::thread receiver([&] {
+        ready = true;
+        result = recv(sv[0], buf, sizeof(buf), 0);
+    });
+    ASSERT_TRUE(wait_for([&] { return ready.load(); }));
+
+    clock.advance(SOCKET_TIMEOUT / 2);
+    ASSERT_EQ(send(sv[1], "abc", 3, 0), 3);
+    clock.advance(SOCKET_CHECK_INTERVAL);
+    receiver.join();
+    EXPECT_EQ(result, 3);
+    EXPECT_EQ(std::string(buf, result), "abc");
+
+    close(sv[0]);
+    close(sv[1]);
+}
+


### PR DESCRIPTION
## Summary
- implement socket timeout handling with a manager embedded in `ClockSimulator`
- add helper to convert `timeval` to chrono duration
- respect timeout values in `recv` and `send` with early-exit checks
- document socket timeout support
- add tests for socket timeout scenarios

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_688002333f8883339f51bf836299f705