### PR TITLE
Fix timerfd header

### DIFF
--- a/dev/ext_docs/timerfd.txt
+++ b/dev/ext_docs/timerfd.txt
@@ -1,4 +1,4 @@
-IMERFD(2)		      System Calls Manual		    TIMERFD(2)
+TIMERFD(2)		      System Calls Manual		    TIMERFD(2)
 
 NAME
        timerfd,	 timerfd_create,  timerfd_gettime,  timerfd_settime  --	timers


### PR DESCRIPTION
## Summary
- correct the heading of the timerfd manpage

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: FakeClockTest aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686c09f6305083339ae3772f5dce4bcf